### PR TITLE
Invalid requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os,sys,re
 
 
 with open('README.md', 'r') as fd:
-  version = '0.9.4'
+  version = '0.9.5'
   author = 'Ryou Ohsawa'
   email = 'ohsawa@ioa.s.u-tokyo.ac.jp'
   description = 'An experimental code to simulate a warped focal plane for small-JASMINE.'
@@ -25,12 +25,12 @@ classifiers = [
 ]
 
 dependencies = [
-  'numpy>=1.16',
+  'numpy>=1.20',
   'scipy>=1.6',
-  'pandas>=1.0.0',
-  'astropy>=4.0',
-  'astroquery>=0.4.1',
-  'matplotlib>=3.0.0',
+  'pandas>=1.1',
+  'astropy>=4.2',
+  'astroquery>=0.4',
+  'matplotlib>=3.3',
 ]
 
 if __name__ == '__main__':

--- a/warpfield/source.py
+++ b/warpfield/source.py
@@ -95,7 +95,7 @@ def display_sources(pointing, sources, title=None):
     ylabel  = 'Declination'
 
   fig = plt.figure(figsize=(8,8))
-  ax = fig.add_subplot(projection=proj)
+  ax = fig.add_subplot(111, projection=proj)
   ax.set_aspect(1.0)
   ax.set_position([0.13,0.10,0.85,0.85])
   ax.scatter(get_lon(sources), get_lat(sources),

--- a/warpfield/telescope.py
+++ b/warpfield/telescope.py
@@ -289,7 +289,7 @@ class Telescope(object):
       epoch (Time)      : the observation epoch.
     '''
     fig = plt.figure(figsize=(8,8))
-    ax = fig.add_subplot()
+    ax = fig.add_subplot(111)
     ax.set_aspect(1.0)
     if sources is not None:
       position = self.optics.imaging(sources, epoch)


### PR DESCRIPTION
The `add_subplot` without argument is not available until `matplotlib-3.1.0`. The dependencies in `setup.py` are updated and we explicitly add `111` as the first argument of `add_subplot`.