### PR TITLE
Feature/forward distortion

### DIFF
--- a/notebook/tutorial_07_simple_distortion_function.ipynb
+++ b/notebook/tutorial_07_simple_distortion_function.ipynb
@@ -219,7 +219,8 @@
     }
    ],
    "source": [
-    "distortion = w.distortion_generator(K=-5e1)\n",
+    "from warpfield.distortion import distortion_generator\n",
+    "distortion = distortion_generator(K=-5e1)\n",
     "jasmine.set_distortion(distortion)\n",
     "jasmine.display_focal_plane(src)"
    ]
@@ -250,7 +251,7 @@
     }
    ],
    "source": [
-    "distortion = w.distortion_generator(S=[-8,4])\n",
+    "distortion = distortion_generator(S=[-8,4])\n",
     "jasmine.set_distortion(distortion)\n",
     "jasmine.display_focal_plane(src)"
    ]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os,sys,re
 
 
 with open('README.md', 'r') as fd:
-  version = '0.9.13'
+  version = '0.9.14'
   author = 'Ryou Ohsawa'
   email = 'ohsawa@ioa.s.u-tokyo.ac.jp'
   description = 'An experimental code to simulate a warped focal plane for small-JASMINE.'

--- a/warpfield/__init__.py
+++ b/warpfield/__init__.py
@@ -4,4 +4,4 @@ from .util import get_projection
 from .source import retrieve_gaia_sources
 from .source import display_sources, display_gaia_sources
 from .telescope import Optics, Detector, Telescope
-from .distortion import distortion_generator
+# from .distortion import distortion_generator

--- a/warpfield/distortion.py
+++ b/warpfield/distortion.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from dataclasses import dataclass, field
 from functools import reduce
 from operator import add
 import numpy as np
@@ -43,3 +44,89 @@ def distortion_generator(K=[0,],S=[0,0],T=[0,],scale=1.0):
     return scale*(position*Kr + Px*Tr)
 
   return distortion
+
+
+@dataclass
+class Sip(object):
+  ''' Simple Imaging Polynomical convention.
+
+  Attributes:
+    order (int):
+        The polynomial order of the SIP convention.
+    A (ndarray):
+        The SIP coefficient matrix for the x-coordinate.
+        The shape of the matrix should be (order+1, order+1).
+    B (ndarray):
+        The SIP coefficient matrix for the y-coordinate.
+        The shape of the matrix should be (order+1, order+1).
+  '''
+  order: int
+  center: np.ndarray = field(init=False)
+  A: np.ndarray
+  B: np.ndarray
+
+  def __post_init__(self):
+    self.center = np.array((0,0))
+    assert self.order >= 0, \
+      f'The polynomical order should be non-negative.'
+    assert self.A.shape == (self.order+1,self.order+1), \
+      f'The shape of A matris should be ({self.order+1}, {self.order+1}).'
+    assert self.B.shape == (self.order+1,self.order+1), \
+      f'The shape of B matris should be ({self.order+1}, {self.order+1}).'
+
+  def apply(self, position: np.ndarray):
+    ''' Modify xy-coordinates with the SIP function.
+
+    Parameters:
+      position (ndarray):
+          An array contains the list of coordinates. The shape of the array
+          should be (N, 2), where N is the number of sources.
+
+    Return:
+      An ndarray instance contains modified coordinates.
+    '''
+    N = position.shape[0]
+    cx,cy = self.center
+    x = position[:,0] - cx
+    y = position[:,1] - cy
+
+    dx = np.zeros_like(x)
+    tmp = np.zeros((N,self.order+1))
+    for m in np.arange(self.order+1):
+      n = self.order+1 - m
+      tmp[:,m] = np.sum([self.A[m,i]*y**i for i in np.arange(n)],axis=0)
+    for m in np.arange(self.order+1):
+      dx += tmp[:,m]*x**m
+
+    dy = np.zeros_like(x)
+    tmp = np.zeros((N,self.order+1))
+    for m in np.arange(self.order+1):
+      n = self.order+1 - m
+      tmp[:,m] = np.sum([self.B[m,i]*y**i for i in np.arange(n)],axis=0)
+    for m in np.arange(self.order+1):
+      dy += tmp[:,m]*x**m
+
+    return np.vstack((x+dx+cx,y+dy+cy)).T
+
+
+@dataclass
+class SipMod(Sip):
+  ''' Modified SIP convention with the distortion center.
+
+  Attributes:
+    order (int):
+        The polynomial order of the SIP convention.
+    center (ndarray):
+        The distortion center.
+    A (ndarray):
+        The SIP coefficient matrix for the x-coordinate.
+        The shape of the matrix should be (order+1, order+1).
+    B (ndarray):
+        The SIP coefficient matrix for the y-coordinate.
+        The shape of the matrix should be (order+1, order+1).
+  '''
+  center: np.ndarray
+
+  def __post_init__(self):
+    assert self.center.size == 2
+    self.center = self.center.flatten()


### PR DESCRIPTION
Implement the forward distortion functions.

In `warpfield`, the distortion function converts _correct_ coordinates into _distorted_ coordinates. However, the analyses in the Jasmine simulation project require the forward conversion. Thus, the distortion function should be defined to convert _distored_ coordinates into _correct_ coordinates.

The `apply` methods in the `Sip` and `SipMod` classes provide such functions. The `SipDistortion` and `SipModDistortion` classes are built on the `Sip` and `SipMod` classes, respectively. They convert _correct_ coordinates_ into _distorted_ coordinates, but the conversion itself is inversely defined.